### PR TITLE
Update clt docs for atlas-consortia-clt

### DIFF
--- a/docs/clt/index.md
+++ b/docs/clt/index.md
@@ -13,6 +13,7 @@ usage: hubmap-clt [-h &#124; --help &#124; -v &#124; --version] [transfer manife
 
 Commands: One of the following commands is required:
 
+```
    transfer manifest-file   Transfer files specified in manifest-file (see
                             below for example) using Globus Transfer.
 			                The transfered files will be stored in the
@@ -40,6 +41,7 @@ Commands: One of the following commands is required:
 -v or --version        Displays the version of the currently installed 
                        hubmap-sdk package
 
+```
 
 #### Manifest Files
 

--- a/docs/clt/install-hubmap-clt.md
+++ b/docs/clt/install-hubmap-clt.md
@@ -18,8 +18,8 @@ During setup, users will have the opportunity to name their Endpoint and login w
 
 #### **_IMPORTANT NOTE ABOUT GLOBUS CONNECT PERSONAL_**
 
-While GCP on linux chooses your home directory as the download location by default, if you are using windows, it is likely that the default download location will not be your home directory. This must be changed or you will experience some difficulty
-finding your downloaded files. To change the download directory on windows 10/11, find the GCP icon in the system tray. If the "g" logo is neither on the right side of the task bar, nor in the hidden icons menu, GCP may not be running; in this case you must launch GCP before chaning any settings.
+While GCP on linux chooses your home directory as the download location by default, if you are using windows, it is likely that the default download location will not be your home directory. Its location can be somewhat inconsistent especially if you use OneDrive. Regardless of your operating system, it is recommended that you confirm where GCP has selected as the default download directory or you may experience some difficulty
+finding your downloaded files. To view the download directory on windows 10/11, find the GCP icon in the system tray. If the "g" logo is neither on the right side of the task bar, nor in the hidden icons menu, GCP may not be running; in this case you must launch GCP first.
 
 <img src="../images/globustray.PNG" alt="GCP System Tray Icon" width="500"/>
 
@@ -31,33 +31,20 @@ Inside the options menu, navigate to the General Tab
 
 <img src="../images/globusoptionsmenu.PNG" alt="GCP General Tab" width="500"/>
 
-Next, inside the text box labeled "Home Folder", change this to be your home directory as shown below. Replace "Your-User-Name" to be the name associated with your home directory
+Here we can see precisely where the globus downloads are mounted. If a specific destination path is used during your download, the path will be relative to this point. 
 
 <img src="../images/globususername.PNG" alt="GCP Home Location" width="500"/>
 
-Now we must navigate to the Access tab next to the General tab and give ourselves permission to use this new directory
-
-<img src="../images/globusaccess.PNG" alt="Globus Access Tab" width="500"/>
-
-Once here, press the plus sign in the bottom right corner to add a new authorized directory
-
-<img src="../images/oldaccessfolder.PNG" alt="Add Access" width="500"/>
-
-You will be prompted to select a directory. Choose the same directory you chose to be your default directory. After adding the new authorized directory, we can remove the old one. Select the previous directory and press the minus button in the bottom right corner to remove it. Be sure to save after you're done 
-
-<img src="../images/removebadpath.PNG" alt="Remove Access" width="500"/>
-
-Once this is all complete, all Globus files will be downloaded relative to this directory. 
 
 #### Installing the HuBMAP CLT
 
-The HuBMAP CLT is available as a Python package.
+The HuBMAP CLT is available as a part of a Python package called `atlas-consortia-clt`.
   - Python 3 is required to run the HuBMAP CLT, an installer for it can be downloaded [here](https://www.python.org/downloads/).
   - It is recommended that you create a new Python virtual environment first with `python3 -m venv /path/to/new/virtual/environment`, more information on Python virtual environments is available [here](https://docs.python.org/3/library/venv.html).
-  - To install the HuBMAP CLT run the pip command shown below after installing Python and creating and activating a new Python virtual environment.
+  - To install the Atlast Consortia CLT run the pip command shown below after installing Python and creating and activating a new Python virtual environment.
 
 ```bash
-pip install hubmap-clt
+pip install atlas-consortia-clt
 ```
 
 This will also install other requirements needed by the the HuBMAP CLT including the Globus [Command Line Tool](https://docs.globus.org/cli/)
@@ -80,5 +67,5 @@ The Globus login screen will open in the default web browser. Follow login instr
 
 #### Using the HuBMAP CLT
 
-At this point, user should be setup and ready to use the Hubmap Command Line Transfer tool. Detailed instructions of 
-its usage can be found [here](using-hubmap-clt.html).
+At this point, user should be set up and ready to use the HuBMAP Command Line Transfer tool. Detailed instructions of 
+its usage can be found [here](index.html).

--- a/docs/clt/view-globus-download-location.md
+++ b/docs/clt/view-globus-download-location.md
@@ -6,13 +6,10 @@ layout: page
 
 All Globus downloads via the HuBMAP-CLT will be performed relative to the default Globus directory or "Home Folder".
 This may not necessarily be your usual Home directory. On Windows for example, your current Documents directory is 
-usually chosen by Globus as the Home Folder. This can be complicated further with One Drive. For example: if your Globus Home 
+often chosen by Globus as the Home Folder. This can be complicated further with One Drive. For example: if your Globus Home 
 Folder is "User\OneDrive\Documents" and, using the HuBMAP-CLT \[--destination] option, you set your download location to be
 "Desktop", you'll find your downloads have been placed in "User\OneDrive\Documents\Desktop" rather than your actual 
-desktop directory.For this reason it is recommended that you change the Globus Home Folder following the instructions in [Using the HuBMAP CLT](using-hubmap-clt.html).
-
-Whether or not you chose to change the default download directory used by Globus, it is useful to be able to find what
-that directory is. This process will be slightly different if depending on your operating system. 
+desktop directory.For this reason it is recommended that you confirm the location of the Globus Home Folder following the instructions in [Using the HuBMAP CLT](using-hubmap-clt.html). This process will be slightly different if depending on your operating system. 
 
 <details>
 <summary>Windows Tutorial</summary>
@@ -24,7 +21,7 @@ that directory is. This process will be slightly different if depending on your 
 <img src="../images/globusoptions.PNG" alt="GCP Windows Context Menu" width="500"/>
 <div>The options menu should open in the access tab. In this screen, you can  view the folders that are accessible by the GCP. Navigate to the general tab.</div>
 <img src="../images/globususername.PNG" alt="Globus Home Folder" width="500"/>
-<div>From this screen we can see the currently selected Home Folder. It is recommended to set this as your home directory.</div>
+<div>From this screen we can see the Home Folder being used by Globus.</div>
 
 
 </details>
@@ -47,7 +44,11 @@ that directory is. This process will be slightly different if depending on your 
 <summary>Linux Tutorial</summary>
 
 
-<div>Unlike Windows and Mac, Linux does not have a persistent taskbar icon. Typically, the Globus Connect Personal endpoint is launched manually from the command line. It is possible to launch GCP in the background and without a Graphical User Interface, however in this case we want to launch the GUI. Launch the GUI by running the following command in the terminal from whichever directory the GCP was initially installed:</div>
+<div>Unlike Windows and Mac, Linux does not have a persistent taskbar icon. Typically, the Globus Connect Personal endpoint is launched manually from the command line. It is possible to launch GCP in the background and without a Graphical User Interface, however in this case we want to launch the GUI. 
+
+**Note** Because it is possible to use GCP without the graphical interface on linux, it is possible you don't have the necessary depenencies to launch the application with the GUI. Consult the GCP <a href="https://docs.globus.org/globus-connect-personal/install/linux/">installation</a> instructions for more information on installing those dependencies.
+
+Launch the GUI by running the following command in the terminal from whichever directory the GCP was initially installed:</div>
 
 
 <code>$ ./globusconnectpersonal-{version-number}/globusconnectpersonal</code>
@@ -63,7 +64,7 @@ that directory is. This process will be slightly different if depending on your 
 <img src="../images/gcpgui.PNG" alt="GCP GUI" width="500"/>
 <div>From the file drop-down menu, click Preferences.</div>
 <img src="../images/gcppreferencesbutton.PNG" alt="GCP Preferences Button" width="500"/>
-<div>Finally, you should arrive at the Access Path Configuration screen. Displayed inside the text-box will be the current GCP Home Folder. You can also conveniently change the Home Folder by modifying the value in the text-box if you wish.</div>
+<div>Finally, you should arrive at the Access Path Configuration screen. Displayed inside the text-box will be the current GCP Home Folder.</div>
 <img src="../images/gcppreferences.PNG" alt="GCP Preferences" width="500"/>
 
 


### PR DESCRIPTION
Fixed broken link from install-hubmap-clt.md to /clt. Fixed command section that was missing formatting. Replaced hubmap-clt with atlas-consortia-clt in the installation instructions. Removed references to changing the download directory until we get that figured out](https://github.com/hubmapconsortium/documentation/commit/5e38724953dad4f56f40f64e7dfe491ad3fe2ffc)