### PR TITLE
Libpitt/typos

### DIFF
--- a/docs/param-search/data-provider-groups.md
+++ b/docs/param-search/data-provider-groups.md
@@ -3,7 +3,7 @@ layout: page
 ---
 
 ## HuBMAP Data Provider Groups
-The following group names are the current (as of 8/25/2024) list of HuBMAP Data Provider groups as stored in the `group_name` attribues of Donors, Samples and Datasets:
+The following group names are the current (as of 8/25/2024) list of HuBMAP Data Provider groups as stored in the `group_name` attributes of Donors, Samples and Datasets:
   - Beth Israel Deaconess Medical Center TMC
   - Broad Institute RTI
   - California Institute of Technology TMC

--- a/docs/param-search/data-query-download-example.md
+++ b/docs/param-search/data-query-download-example.md
@@ -19,7 +19,7 @@ The following query will return all CODEX (`dataset_type=CODEX`) Datasets run on
  GET https://search.api.hubmapconsortium.org/v3/param-search/datasets?dataset_type=CODEX&metadata.metadata.acquisition_instrument_model=BZ-X800&origin_samples.organ=SP
 ```
 
-As is, if this query is submitted via HTTP GET it will produce a json Response with an array of dataset objects which match the query.  Adding the `produce-clt-manifest=true` option to this query will instead prduce a list of Dataset IDs pointing to the Datasets that match this query in a format that will be directly usable by the [HuBMAP Command Line Transfer Tool](../clt/index.html).
+As is, if this query is submitted via HTTP GET it will produce a json Response with an array of dataset objects which match the query.  Adding the `produce-clt-manifest=true` option to this query will instead produce a list of Dataset IDs pointing to the Datasets that match this query in a format that will be directly usable by the [HuBMAP Command Line Transfer Tool](../clt/index.html).
 
 To run this from the command line and save the results to a file run:
 ```

--- a/docs/param-search/data-query-download-example.md
+++ b/docs/param-search/data-query-download-example.md
@@ -51,7 +51,7 @@ To use the HuBMAP CLT tool to download the data from these datasets:
   hubmap-clt login
   ```
   Globus login screen will open in your default web browser.  Follow the instructions to log in.  For publicly available HuBMAP data any login will work (your institution, Google, GitHub, etc..).
-  - Download the data using the manifest file genrated above:
+  - Download the data using the manifest file generated above:
   ```
   hubmap-clt transfer dataset-manifest-for-download.out
   ```

--- a/docs/param-search/data-query-download-example.md
+++ b/docs/param-search/data-query-download-example.md
@@ -44,7 +44,7 @@ To use the HuBMAP CLT tool to download the data from these datasets:
 
   - Install the Globus Connect Personal client and the HuBMAP CLT per the [HuBMAP CLT Setup Instructions](../clt/install-hubmap-clt.html)
     - Python 3.9 or greater is required for the HuBMAP CLT, install from the [Python Downloads page](https://www.python.org/downloads/)
-    - Setup Note: A common issue arrises between the configuration of the GCP client and HuBMAP CLT.  By default HuBMAP CLT stores files in the user's home directory under a directory called `hubmap-downloads`, so make sure to configure the GCP client by goint to "Preferences"-->"Access" and adding the `hubmap-downloads` directory in the user's home like (Example shown is Mac OS X):<br/>
+    - Setup Note: A common issue arrises between the configuration of the GCP client and HuBMAP CLT.  By default, HuBMAP CLT stores files in the user's home directory under a directory called `hubmap-downloads`, so make sure to configure the GCP client by going to "Preferences"-->"Access" and adding the `hubmap-downloads` directory in the user's home like (Example shown is Mac OS X):<br/>
     <img src="/images/globus-properties.png" alt="HuBMAP Provenance" width="400"/>
   - On the command line log into the HuBMAP Globus server using:
   ```

--- a/docs/param-search/index.md
+++ b/docs/param-search/index.md
@@ -64,7 +64,7 @@ To run the same query finding all ATACseq datasets, but produce a manifest file 
  GET https://search.api.hubmapconsortium.org/v3/param-search/datasets?origin_samples.organ=RL&dataset_type=ATACseq&produce-clt-manifest=true
 ```
 
-This will produce a list of dataset ids in a format usable by the [HuBMAP Command Line Transfer Tool](../clt/index.html) to download the data.  A Linix/MAC command line example of how to produce a manifest file:
+This will produce a list of dataset ids in a format usable by the [HuBMAP Command Line Transfer Tool](../clt/index.html) to download the data.  A Linux/MAC command line example of how to produce a manifest file:
 
 ```
 curl "https://search.api.hubmapconsortium.org/v3/param-search/datasets?origin_samples.organ=RL&dataset_type=ATACseq&produce-clt-manifest=true" > manifest.out

--- a/docs/param-search/index.md
+++ b/docs/param-search/index.md
@@ -6,12 +6,12 @@ layout: page
 ## Overview:
 The HuBMAP parameterized search endpoints provide an option for a simpler programatic search mechanism vs using the full search-api `/search` endpoints. Both the `/param-search` and `/search` endpoints are backed by Elasticsearch indices, but the parameterized search facility follows a simple RESTful parameter scheme vs the complicated Elasticsearch json query syntax used by the full `/search` mechanism. The `/param-search` endpoint only allows for searching specific values of "allowable value" attributes "anded" together vs the full logic and attribute types available in the [Elasticsearch supported queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) available in the full `/search` endpoint.
 
-This page documents the pubic usage of the `/param-search` endpoint and its varients vs the fully documented [HuBMAP Search API](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158), which includes less detail of the `/param-search` endpoint, but also detail of the more capable, but more complicated `/search` endpoint.
+This page documents the public usage of the `/param-search` endpoint and its variants vs the fully documented [HuBMAP Search API](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158), which includes less detail of the `/param-search` endpoint, but also detail of the more capable, but more complicated `/search` endpoint.
 
 ## Description: 
 The `/param-search/<entity-type>` endpoint of the [HuBMAP Search API service](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158) is a RESTful search interface allowing simple attribute matching by providing attribute value pairs as query parameters at the end of the RESTful URL call.  Multiple query parameters can be provided, which will be "ANDed" together in the query logic, for example the URL `https://searchapi.service.endpoint/entity-type?param1=value1&param2=value2&param3=value3` will find all entities of type "entity-type" where entity.param1 equals "value1" and entity.param2 equals "value2" and entity.param3 equals "value3"
 
-For an example of how to used the `produce-clt-manifest` option (described below), see the [Example Query and Download page](data-query-download-example.html)
+For an example of how to use the `produce-clt-manifest` option (described below), see the [Example Query and Download page](data-query-download-example.html)
 
 ### Inputs
  - <entity-type> The type of entity to search for provided as an in-URL resource parameter after the `/param-search/` endpoint name, where valid entity types are:
@@ -59,7 +59,7 @@ A json array containing Dataset objects will be returned.
 
 ---
 
-To run the same query finding all ATACseq datasets, but produce a mainifest file to download all of the data instead of producing the json of all dataset information, add the `produce-clt-manifest=true` option
+To run the same query finding all ATACseq datasets, but produce a manifest file to download all of the data instead of producing the json of all dataset information, add the `produce-clt-manifest=true` option
 ```
  GET https://search.api.hubmapconsortium.org/v3/param-search/datasets?origin_samples.organ=RL&dataset_type=ATACseq&produce-clt-manifest=true
 ```


### PR DESCRIPTION
Change log:
1. Fix typos

@shirey Wasn't sure what was meant here:
Not sure if the following is supposed to be "composed of" or "composited from" or actually meant to type "composed from":
https://github.com/hubmapconsortium/documentation/blob/main/docs/param-search/schema-dataset.md?plain=1#L14
https://github.com/hubmapconsortium/documentation/blob/main/docs/param-search/schema-sample.md?plain=1#L18

Here is written "composited from":
https://github.com/hubmapconsortium/documentation/blob/main/docs/param-search/schema-donor.md?plain=1#L17

Thinking supposed to be "composited from" but unsure, so I left that alone.